### PR TITLE
Reduce frequency to Monday only

### DIFF
--- a/.github/workflows/check_for_probely_high_vulnerabilities.yml
+++ b/.github/workflows/check_for_probely_high_vulnerabilities.yml
@@ -3,7 +3,7 @@ name: Probely high vulnerability checker
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 9 * * *'  # every Monday at 9am
+    - cron: '0 9 * * 1'  # every Monday at 9am
 
 jobs:
   scheduled-job:


### PR DESCRIPTION
The Slack channel is quiet, so checking every morning is creating noise that and makes it less likely to be visited.

The _right_ solution for this is to:

1. Only post a full summary of the outstanding high issues once a week on Monday at 9am (the previous check cadence)
2. Post _new_ high findings the morning they're discovered. This means filtering the results by date for non-Monday runs

This PR improves things until we get around to that change.